### PR TITLE
Fix/scroll tabs

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -19,6 +19,7 @@
     <em:contributor>bb10 (Linux and Windows theme contributions)</em:contributor>
     <em:contributor>Frank Yan (various theming fixes)</em:contributor>
     <em:contributor>Rob Campbell (some UI love)</em:contributor>
+    <em:contributor>Erica Wright</em:contributor>
     <em:targetApplication>
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- Firefox -->

--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -264,6 +264,7 @@ VerticalTabs.prototype = {
         });
 
         tabs.addEventListener("TabOpen", this, false);
+        tabs.addEventListener("TabSelect", this, false);
         tabs.addEventListener("TabClose", this, false);
         tabs.addEventListener("TabPinned", this, false);
         tabs.addEventListener("TabUnpinned", this, false);
@@ -294,6 +295,7 @@ VerticalTabs.prototype = {
             tabs.tabbox.orient = "vertical"; // probably not necessary
             tabs.removeAttribute("width");
             tabs.removeEventListener("TabOpen", this, false);
+            tabs.removeEventListener("TabSelect", this, false);
             tabs.removeEventListener("TabClose", this, false);
             tabs.removeEventListener("TabPinned", this, false);
             tabs.removeEventListener("TabUnpinned", this, false);
@@ -386,7 +388,15 @@ VerticalTabs.prototype = {
         case "popupshowing":
             this.onPopupShowing(aEvent);
             return;
+        case "TabSelect":
+            this.onTabSelect(aEvent);
+            return;
         }
+    },
+
+    onTabSelect: function(aEvent) {
+      let tab = aEvent.target;
+      tab.scrollIntoView();
     },
 
     onTabOpen: function(aEvent) {


### PR DESCRIPTION
Reviewer: @bwinton 

### Changes
- keep tab in view on creating a new tab
- keep tab in view on changing active tab

### How to Test
- open many tabs so there is a scroll bar 
- add a new tab and see the scroll bar move to the bottom
- `ctrl + tab` through the tabs

### Issue
- https://github.com/bwinton/VerticalTabs/issues/136

### Notes
- The bottom of the tabs and window will be cut off, that is due to another bug: 

https://github.com/bwinton/VerticalTabs/issues/148

https://github.com/bwinton/VerticalTabs/issues/146