### PR TITLE
Fix/customize

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -106,7 +106,7 @@ function startup(data, reason) {
   unload(vtInit());
   watchWindows(function (window) {
     if (window.toolbar.visible) {
-      let vt = new VerticalTabs(window, {newPayload, addPingStats, AppConstants});
+      let vt = new VerticalTabs(window, {newPayload, addPingStats, AppConstants, setDefaultPrefs});
       unload(vt.unload.bind(vt), window);
     }
   }, 'navigator:browser');


### PR DESCRIPTION
@bwinton

### Changes
- customize menu now has a toolbar on the top which can be customized
- when clicking `restore defaults` title bar does not resize and/or disappear

### How To Test
- open customize tab - move things around
- click `restore defaults` watch the title bar

### Notes
- possible to achieve title bar not changing with css - might be more efficient than setting up another listener?

### Issues
- https://github.com/bwinton/VerticalTabs/issues/168