### PR TITLE
Make pinned tabs more prominent visually

### DIFF
--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -199,6 +199,7 @@
 
 .tabbrowser-tab[pinned] {
   border-left: 4px solid #0996f8 !important;
+  background-image: linear-gradient(to right, #0996f8, transparent 10%) !important;
 }
 
 .tabbrowser-tab:not([selected="true"]):hover {
@@ -392,10 +393,8 @@
 }
 
 .tabbrowser-tab[pinned][titlechanged]:not([visuallyselected="true"]) {
-  background-image: radial-gradient(22px at left center, #0996f8 19%, transparent 22%) !important;
-  background-position: -2px center !important;
-  background-repeat: no-repeat !important;
-  background-size: 100% !important;
+  border-left: 4px solid #ff9500 !important;
+  background-image: linear-gradient(to right, #0996f8, transparent 10%) !important;
 }
 
 .tabbrowser-tab > .tab-stack > .tab-content[pinned][titlechanged]:not([visuallyselected="true"]) {


### PR DESCRIPTION
Please can you make the difference between normal tabs and pinned tabs more easily scannable?

This changes the visual representation of pinned tabs by adding a linear gradient background color.

I am color blind and have no taste. It's hard, but I'm trying.