### PR TITLE
change removeTab to _endRemoveTab

### DIFF
--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -109,7 +109,7 @@ VerticalTabs.prototype = {
     }.bind(this);
 
     this.window.VerticalTabs = this;
-    this.removeTab = this.window.gBrowser.removeTab;
+    this._endRemoveTab = this.window.gBrowser._endRemoveTab;
     this.inferFromText = this.window.ToolbarIconColor.inferFromText;
     let AppConstants = this.AppConstants;
     let window = this.window;
@@ -149,7 +149,7 @@ VerticalTabs.prototype = {
     }.bind(this.window.ToolbarIconColor);
     this.unloaders.push(function () {
       this.window.ToolbarIconColor.inferFromText = this.inferFromText;
-      this.window.gBrowser.removeTab = this.removeTab;
+      this.window.gBrowser._endRemoveTab = this._endRemoveTab;
       this.window.BrowserOpenTab = this.BrowserOpenTab;
       delete this.window.VerticalTabs;
     });
@@ -435,7 +435,7 @@ VerticalTabs.prototype = {
       aTab.setAttribute('crop', 'end');
     }
 
-    this.window.gBrowser.removeTab = (aTab) => {
+    this.window.gBrowser._endRemoveTab = (aTab) => {
       aTab.classList.remove('tab-visible');
       aTab.classList.add('tab-hidden');
       aTab.addEventListener('animationend', (e) => {
@@ -443,7 +443,7 @@ VerticalTabs.prototype = {
           let tabStack = this.document.getAnonymousElementByAttribute(aTab, 'class', 'tab-stack');
           tabStack.collapsed = true; //there is a visual jump if we do not collapse the tab before the end of the animation
         } else if (e.animationName === 'slide-out') {
-          this.removeTab.bind(this.window.gBrowser)(aTab);
+          this._endRemoveTab.bind(this.window.gBrowser)(aTab);
         }
       });
     };


### PR DESCRIPTION
reviewer: @bwinton

#### Changes
 - to allow onunload trigger to resolve before animating the tab closed, changed removeTab to _endRemoveTab

fixes:  #317 