### PR TITLE
Port @gijsk's fix from jdashg#10.

### DIFF
--- a/vertical-tabbrowser.xml
+++ b/vertical-tabbrowser.xml
@@ -243,6 +243,9 @@
           switch (aEvent.type) {
           case 'load':
             this.updateVisibility();
+            if (typeof TabsInTitlebar._updateOnInit != 'undefined') {
+              TabsInTitlebar.init();
+            }
             break;
           case 'resize':
             if (aEvent.target !== window) {


### PR DESCRIPTION
fix: Remove the white bar from the titlebar.  📶

Call `TabsInTitlebar.init();` to recalculate the titlebar size.

Fixes #319.
Reviewer: @ericawright