### PR TITLE
fix: bottom tab being cut off

### DIFF
--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -31,6 +31,13 @@
   height: calc(100vh - 41px);
 }
 
+@media (-moz-os-version: windows-xp), (-moz-os-version: windows-vista), (-moz-os-version: windows-win7), (-moz-os-version: windows-win8), (-moz-os-version: windows-win10) {
+  .tabbrowser-arrowscrollbox,
+  .tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {
+    height: calc(100vh - 42px);
+  }
+}
+
 #verticaltabs-box .tabbrowser-arrowscrollbox > scrollbox {
   overflow-y: hidden !important;
 }

--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -23,8 +23,12 @@
 }
 
 .tabbrowser-arrowscrollbox {
-  height: calc(100vh - 42px);
+  height: calc(100vh - 63px);
   flex: 1 0;
+}
+
+.tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {
+  height: calc(100vh - 41px);
 }
 
 #verticaltabs-box .tabbrowser-arrowscrollbox > scrollbox {


### PR DESCRIPTION
reviewer: @bwinton

fix: bottom tab being cut off ✂️ 

- remove extra 22px height from .tabbrowser-arrowscrollbox to account for lightweight themes
- remove 1px height from  .tabbrowser-arrowscrollbox that is visible in certain themes (on mac)
- custom rule for windows to remain at 42px always

fixes: #238
