### PR TITLE
fix: show muted icon if no sound playing. 🙊 

### DIFF
--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -284,6 +284,7 @@
   display: none;
 }
 
+.tab-icon-overlay[muted],
 .tab-icon-overlay[soundplaying] {
   display: -moz-box !important;
 }


### PR DESCRIPTION
reviewer: @bwinton

show the .tab-icon-overlay if muted, but no sound playing.

fixes: #323.

