### PR TITLE
feature: add button to toggle new tab open location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SOURCES = \
 	chrome.manifest \
 	install.rdf \
 	multiselect.jsm \
+	options.xul \
 	override-bindings.css \
 	skin/* \
 	tabdatastore.jsm \

--- a/options.xul
+++ b/options.xul
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<vbox xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+  <setting type="bool"
+           pref="extensions.verticaltabs.opentabstop"
+           title="New tabs are opened at the top"/>
+</vbox>

--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -101,19 +101,27 @@ function VerticalTabs(window, {newPayload, addPingStats, AppConstants, setDefaul
 VerticalTabs.prototype = {
 
   init: function () {
-    this.BrowserOpenTab = this.window.BrowserOpenTab;
-    this.window.BrowserOpenTab = function () {
-      this.pushToTop = true;
-      this.window.openUILinkIn(this.window.BROWSER_NEW_TAB_URL, 'tab');
-      this.pushToTop = false;
-    }.bind(this);
-
     this.window.VerticalTabs = this;
     this._endRemoveTab = this.window.gBrowser._endRemoveTab;
     this.inferFromText = this.window.ToolbarIconColor.inferFromText;
     let AppConstants = this.AppConstants;
     let window = this.window;
     let document = this.document;
+
+    try {
+      Services.prefs.getBoolPref('extensions.verticaltabs.opentabstop');
+    } catch (ex) {
+      if (ex.result === Components.results.NS_ERROR_UNEXPECTED) {
+        Services.prefs.setBoolPref('extensions.verticaltabs.opentabstop', true);
+      }
+    }
+
+    this.BrowserOpenTab = this.window.BrowserOpenTab;
+    this.window.BrowserOpenTab = function () {
+      this.pushToTop = Services.prefs.getBoolPref('extensions.verticaltabs.opentabstop');
+      this.window.openUILinkIn(this.window.BROWSER_NEW_TAB_URL, 'tab');
+    }.bind(this);
+
     window.ToolbarIconColor.inferFromText = function () {
       if (!this._initialized){
         return;


### PR DESCRIPTION
reviewer: @bwinton 🚮 

**open for 👀 and proof-of-concept**  

TODO:
- needs UI love
  - should it be a button, or in a menu, or...?
- metrics

(optional) provide option for:
- opening ctrl-click tabs at top?
- open ctrl-click tabs above or below current tab?

fixes: #322 