### PR TITLE
fix: remove slide-in animation from dragging tabs 🐉 📑 

### DIFF
--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -114,6 +114,13 @@ VerticalTabs.prototype = {
     let AppConstants = this.AppConstants;
     let window = this.window;
     let document = this.document;
+
+    window.addEventListener('animationend', function (e) {
+      if (e.animationName === 'slide-fade-in') {
+        e.target.classList.remove('tab-visible');
+      }
+    });
+
     window.ToolbarIconColor.inferFromText = function () {
       if (!this._initialized){
         return;
@@ -453,7 +460,6 @@ VerticalTabs.prototype = {
     }
 
     this.window.gBrowser._endRemoveTab = (aTab) => {
-      aTab.classList.remove('tab-visible');
       aTab.classList.add('tab-hidden');
       aTab.addEventListener('animationend', (e) => {
         if (e.animationName === 'fade-out') {

--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -115,11 +115,21 @@ VerticalTabs.prototype = {
     let window = this.window;
     let document = this.document;
 
-    window.addEventListener('animationend', function (e) {
+    window.addEventListener('animationend', (e) => {
+      let tab = e.target;
       if (e.animationName === 'slide-fade-in') {
-        e.target.classList.remove('tab-visible');
+        tab.classList.remove('tab-visible');
+      } else if (e.animationName === 'fade-out') {
+        let tabStack = this.document.getAnonymousElementByAttribute(tab, 'class', 'tab-stack');
+        tabStack.collapsed = true; //there is a visual jump if we do not collapse the tab before the end of the animation
+      } else if (e.animationName === 'slide-out') {
+        this._endRemoveTab.bind(this.window.gBrowser)(tab);
       }
     });
+
+    window.gBrowser._endRemoveTab = (aTab) => {
+      aTab.classList.add('tab-hidden');
+    };
 
     window.ToolbarIconColor.inferFromText = function () {
       if (!this._initialized){
@@ -458,18 +468,6 @@ VerticalTabs.prototype = {
     } else {
       aTab.setAttribute('crop', 'end');
     }
-
-    this.window.gBrowser._endRemoveTab = (aTab) => {
-      aTab.classList.add('tab-hidden');
-      aTab.addEventListener('animationend', (e) => {
-        if (e.animationName === 'fade-out') {
-          let tabStack = this.document.getAnonymousElementByAttribute(aTab, 'class', 'tab-stack');
-          tabStack.collapsed = true; //there is a visual jump if we do not collapse the tab before the end of the animation
-        } else if (e.animationName === 'slide-out') {
-          this._endRemoveTab.bind(this.window.gBrowser)(aTab);
-        }
-      });
-    };
   },
 
   unload: function () {


### PR DESCRIPTION
reviewer: @bwinton 

add listener and remove animating class once first animation is finished. 
refactor: don't add a listener on every new tab created, add to window instead. 😊 

fixes: #326 

**Notes:**
let me know if you want the refactor in a separate PR