### PR TITLE
Style: windows edits 👸 

### DIFF
--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -31,13 +31,6 @@
   height: calc(100vh - 41px);
 }
 
-@media (-moz-os-version: windows-xp), (-moz-os-version: windows-vista), (-moz-os-version: windows-win7), (-moz-os-version: windows-win8), (-moz-os-version: windows-win10) {
-  .tabbrowser-arrowscrollbox,
-  .tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {
-    height: calc(100vh - 42px);
-  }
-}
-
 #verticaltabs-box .tabbrowser-arrowscrollbox > scrollbox {
   overflow-y: hidden !important;
 }
@@ -452,6 +445,13 @@
   background-image: none !important;
 }
 
+@media (-moz-os-version: windows-xp), (-moz-os-version: windows-vista), (-moz-os-version: windows-win10) {
+  .tabbrowser-arrowscrollbox,
+  .tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {
+    height: calc(100vh - 42px);
+  }
+}
+
 @media (-moz-os-version: windows-win7), (-moz-os-version: windows-win8) {
   #appcontent {
     top: 1px;
@@ -468,6 +468,11 @@
 
   #nav-bar {
     border-left: none !important;
+  }
+
+  .tabbrowser-arrowscrollbox,
+  .tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {
+    height: calc(100vh - 46px);
   }
 }
 

--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -354,12 +354,9 @@
 }
 
 #TabsToolbar {
+  padding: 0 !important;
   display: flex;
   flex: 0 0 40px;
-}
-
-#main-window[tabsintitlebar] #TabsToolbar {
-  padding: 0 !important;
 }
 
 #TabsToolbar > toolbarbutton,

--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -445,6 +445,13 @@
   background-image: none !important;
 }
 
+@media (-moz-os-version: windows-xp), (-moz-os-version: windows-vista), (-moz-os-version: windows-win10), (-moz-os-version: windows-win7), (-moz-os-version: windows-win8) {
+  /*remove clear bottom border in themes*/
+  #TabsToolbar {
+    border-bottom: 1px solid ThreeDShadow !important;
+  }
+}
+
 @media (-moz-os-version: windows-xp), (-moz-os-version: windows-vista), (-moz-os-version: windows-win10) {
   .tabbrowser-arrowscrollbox,
   .tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {

--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -474,3 +474,10 @@
     border-left: none !important;
   }
 }
+
+/* win10 needs to be 1 px smaller*/
+@media (-moz-os-version: windows-win10) {
+  #TabsToolbar {
+    flex: 0 0 39px;
+  }
+}

--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -458,13 +458,12 @@
   }
 
   #verticaltabs-box {
-    top: 1px;
     border-left: 1px solid rgb(160, 160, 160);
   }
 
   #TabsToolbar {
     margin: 0 !important;
-    flex: 0 0 44px !important;
+    flex: 0 0 42px !important;
   }
 
   #nav-bar {

--- a/skin/light/light.css
+++ b/skin/light/light.css
@@ -476,10 +476,19 @@
   #nav-bar {
     border-left: none !important;
   }
+}
 
+@media (-moz-os-version: windows-win8) {
   .tabbrowser-arrowscrollbox,
   .tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {
     height: calc(100vh - 46px);
+  }
+}
+
+@media (-moz-os-version: windows-win7) {
+  .tabbrowser-arrowscrollbox,
+  .tabbrowser-arrowscrollbox:not(:-moz-lwtheme) {
+    height: calc(100vh - 44px);
   }
 }
 


### PR DESCRIPTION
reviewer: @bwinton 
**open for visibility** (there are still more bits to tidy)

remove padding from #TabsToolBar.
set #TabsToolBar height to align better with #appcontent.
remove unnecessary scroll bar in win 7, 8, 10.
remove clear border under #TabsToolBar in themes. 


fixes: #88. 
fixes: #169.
