### PR TITLE
fix: toolbar icons correctly change color in dark themes

### DIFF
--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -148,7 +148,7 @@ VerticalTabs.prototype = {
         return rgb.map(x => parseInt(x));
       }
 
-      let toolbarSelector = '#verticaltabs-box, #verticaltabs-box > toolbar:not([collapsed=true]):not(#addon-bar)';
+      let toolbarSelector = '#verticaltabs-box, #verticaltabs-box > toolbar:not([collapsed=true]):not(#addon-bar), #navigator-toolbox > toolbar:not([collapsed=true]):not(#addon-bar)';
       if (AppConstants.platform === 'macosx') {
         toolbarSelector += ':not([type=menubar])';
       }


### PR DESCRIPTION
r: @bwinton 

restore #navigator-toolbox children to receive brighttext attr

fixes: #305.