### PR TITLE
fix: click on find icon 🌁 

### DIFF
--- a/verticaltabs.jsm
+++ b/verticaltabs.jsm
@@ -357,6 +357,9 @@ VerticalTabs.prototype = {
       'id': 'tabs-search'
     });
     find_input.appendChild(search_icon);
+    search_icon.addEventListener('click', function (e) {
+      find_input.focus();
+    });
     find_input.addEventListener('input', this.filtertabs.bind(this));
     this.window.addEventListener('keyup', (e) => {
       if(e.keyCode === 27) {


### PR DESCRIPTION
r: @bwinton 

on clicking on the find icon focus the find bar.

fixes #420.
