### PR TITLE
fix: Hide splitter when in fullscreen

### DIFF
--- a/skin/base.css
+++ b/skin/base.css
@@ -175,7 +175,8 @@
   background-color: #333 !important;
 }
 
-#main-window[inFullscreen][inDOMFullscreen] #verticaltabs-box {
+#main-window[inFullscreen][inDOMFullscreen] #verticaltabs-box,
+#main-window[inFullscreen][inDOMFullscreen] #verticaltabs-splitter {
   visibility: collapse;
 }
 


### PR DESCRIPTION
r: @bwinton 

When in fullscreen, the pinned TC no longer shows.

Fixes: #441.